### PR TITLE
Ring data differentiation

### DIFF
--- a/ExtractScanResults.C
+++ b/ExtractScanResults.C
@@ -52,11 +52,12 @@ void ExtractResults()
     param_run = param + counter*param_step;
     //fa = 89;
 
-    tmp = (TH1D*)file->Get("CathodeEventsDistrHist");
+    tmp = (TH1D*)file->Get("R1_CathodeEventsDistrHist");
     
     hst = (TH1D*)tmp->Clone(Form("CEH_%s",runID.Data()));
     hst->SetTitle("Photoelectron Distribution");
     hst->GetXaxis()->SetTitle("Photoelectrons");
+    hst->GetXaxis()->SetRangeUser(1,100);
     hst->SetDirectory(0);
 
     m = FindGraph(fa,hr);
@@ -234,7 +235,7 @@ void DoFit(TH1D *hst, Double_t *fitR, Double_t *fitE)
   gStyle->SetLabelSize(0.03,"x");
   gStyle->SetLabelSize(0.03,"y");
   
-  hst->GetXaxis()->SetRange(0,100);
+  //hst->GetXaxis()->SetRange(1,100);
   hst->Draw();
   fitsnr->Draw("lsame");
   

--- a/include/MOLLEROptAnalysis.hh
+++ b/include/MOLLEROptAnalysis.hh
@@ -37,8 +37,22 @@ public:
   void AddToAverageQuartzOptPhotonDist(Float_t wvl, Float_t wgt){QuartzOptPhotonDistrHist->Fill(wvl,wgt);};
   void AddToAverageLightGuideOptPhotonDist(Float_t wvl, Float_t wgt){LightGuideOptPhotonDistrHist->Fill(wvl,wgt);};
 
-  void AddPhotoElectronEvent(Double_t pe){ PhotoElectronDistrHist->Fill(pe);};
-  void AddCathodeDetectionEvent(Int_t events) {CathodeEventsDistrHist->Fill(events);};
+  void R1_AddPhotoElectronEvent(Double_t pe){ R1_PhotoElectronDistrHist->Fill(pe);};
+  void R1_AddCathodeDetectionEvent(Int_t events) {R1_CathodeEventsDistrHist->Fill(events);};
+  void R2_AddPhotoElectronEvent(Double_t pe){ R2_PhotoElectronDistrHist->Fill(pe);};
+  void R2_AddCathodeDetectionEvent(Int_t events) {R2_CathodeEventsDistrHist->Fill(events);};
+  void R3_AddPhotoElectronEvent(Double_t pe){ R3_PhotoElectronDistrHist->Fill(pe);};
+  void R3_AddCathodeDetectionEvent(Int_t events) {R3_CathodeEventsDistrHist->Fill(events);};
+  void R4_AddPhotoElectronEvent(Double_t pe){ R4_PhotoElectronDistrHist->Fill(pe);};
+  void R4_AddCathodeDetectionEvent(Int_t events) {R4_CathodeEventsDistrHist->Fill(events);};
+  void R5_AddPhotoElectronEvent(Double_t pe){ R5_PhotoElectronDistrHist->Fill(pe);};
+  void R5_AddCathodeDetectionEvent(Int_t events) {R5_CathodeEventsDistrHist->Fill(events);};
+  void R6_AddPhotoElectronEvent(Double_t pe){ R6_PhotoElectronDistrHist->Fill(pe);};
+  void R6_AddCathodeDetectionEvent(Int_t events) {R6_CathodeEventsDistrHist->Fill(events);};
+  void R7_AddPhotoElectronEvent(Double_t pe){ R7_PhotoElectronDistrHist->Fill(pe);};
+  void R7_AddCathodeDetectionEvent(Int_t events) {R7_CathodeEventsDistrHist->Fill(events);};
+  void R8_AddPhotoElectronEvent(Double_t pe){ R8_PhotoElectronDistrHist->Fill(pe);};
+  void R8_AddCathodeDetectionEvent(Int_t events) {R8_CathodeEventsDistrHist->Fill(events);};
 
   MOLLEROptMainEvent* MOLLERMainEvent;
 
@@ -54,8 +68,22 @@ private:
   TProfile*    PMTOptPhotonDistrHist;
   TProfile*    QuartzOptPhotonDistrHist;
   TProfile*    LightGuideOptPhotonDistrHist;
-  TH1D*    PhotoElectronDistrHist;
-  TH1D*    CathodeEventsDistrHist;
+  TH1D*    R1_PhotoElectronDistrHist;
+  TH1D*    R1_CathodeEventsDistrHist;
+  TH1D*    R2_PhotoElectronDistrHist;
+  TH1D*    R2_CathodeEventsDistrHist;
+  TH1D*    R3_PhotoElectronDistrHist;
+  TH1D*    R3_CathodeEventsDistrHist;
+  TH1D*    R4_PhotoElectronDistrHist;
+  TH1D*    R4_CathodeEventsDistrHist;
+  TH1D*    R5_PhotoElectronDistrHist;
+  TH1D*    R5_CathodeEventsDistrHist;
+  TH1D*    R6_PhotoElectronDistrHist;
+  TH1D*    R6_CathodeEventsDistrHist;
+  TH1D*    R7_PhotoElectronDistrHist;
+  TH1D*    R7_CathodeEventsDistrHist;
+  TH1D*    R8_PhotoElectronDistrHist;
+  TH1D*    R8_CathodeEventsDistrHist;
   
   TVectorD *NumberOfPrimaries;
   Float_t OptPhotonDist[800];

--- a/include/MOLLEROptDetectorEvent.hh
+++ b/include/MOLLEROptDetectorEvent.hh
@@ -27,6 +27,7 @@ private:
   vector <Float_t> PMTPhotonEnergy;
   vector <Float_t> PMTCathodeHitX;
   vector <Float_t> PMTCathodeHitY;
+  vector <Float_t> PMTCathodeHitZ;
   vector <Float_t> PMTWindowReflectionAngle;
   
   vector <Int_t> LightGuideTrackHit;
@@ -97,6 +98,7 @@ public:
   void AddPMTTrackHit(Int_t tID){PMTTrackHit = tID;};
   void AddPMTHitPositionX(Float_t x) {PMTCathodeHitX.push_back(x);};
   void AddPMTHitPositionY(Float_t y) {PMTCathodeHitY.push_back(y);};
+  void AddPMTHitPositionZ(Float_t z) {PMTCathodeHitZ.push_back(z);};
   void AddQuartzHitPositionX(Float_t x) {QuartzHitX.push_back(x);};
   void AddQuartzHitPositionY(Float_t y) {QuartzHitY.push_back(y);};
   void AddPMTWindowReflectionAngle(Float_t ang) {PMTWindowReflectionAngle.push_back(ang);};

--- a/include/MOLLEROptDetectorEvent.hh
+++ b/include/MOLLEROptDetectorEvent.hh
@@ -41,6 +41,7 @@ private:
   vector <Int_t> QuartzTrackHit;
   vector <Float_t> QuartzHitX;
   vector <Float_t> QuartzHitY;
+  vector <Float_t> QuartzHitZ;
   // vector <Float_t> QuartzPhotonEnergy;
   Float_t QuartzPhotonEnergy;
   vector <Float_t> QuartzSecondaryPhotonAngle;
@@ -101,6 +102,7 @@ public:
   void AddPMTHitPositionZ(Float_t z) {PMTCathodeHitZ.push_back(z);};
   void AddQuartzHitPositionX(Float_t x) {QuartzHitX.push_back(x);};
   void AddQuartzHitPositionY(Float_t y) {QuartzHitY.push_back(y);};
+  void AddQuartzHitPositionZ(Float_t z) {QuartzHitZ.push_back(z);};
   void AddPMTWindowReflectionAngle(Float_t ang) {PMTWindowReflectionAngle.push_back(ang);};
 
   void AddTrackInitMomDirection(Float_t x, Float_t y, Float_t z) {

--- a/include/MOLLEROptTrackingReadout.hh
+++ b/include/MOLLEROptTrackingReadout.hh
@@ -70,7 +70,15 @@ private:
   vector <TrackData*> Tracks;
   Int_t ElectronTracks;
   Int_t PhotonTracks;
-  Int_t CathodeDetections;
+  //Int_t CathodeDetections;
+  Int_t R1_CathodeDetections;
+  Int_t R2_CathodeDetections;
+  Int_t R3_CathodeDetections;
+  Int_t R4_CathodeDetections;
+  Int_t R5_CathodeDetections;
+  Int_t R6_CathodeDetections;
+  Int_t R7_CathodeDetections;
+  Int_t R8_CathodeDetections;
 
   TH2D *DetectorRateGlobal;
   TH2D *DetectorRateGlobalRotated;
@@ -104,7 +112,15 @@ private:
   void AddSecPhoton(Int_t id, Float_t ang, Float_t wvl);
   void AddStepNCherenkovs(Int_t n, Int_t nsec);
   void IncrementEventCathodeDetection(Int_t ID);
-  Int_t GetCathodeDetections() {return CathodeDetections;};
+  //Int_t GetCathodeDetections() {return CathodeDetections;};
+  Int_t R1_GetCathodeDetections() {return R1_CathodeDetections;};
+  Int_t R2_GetCathodeDetections() {return R2_CathodeDetections;};
+  Int_t R3_GetCathodeDetections() {return R3_CathodeDetections;};
+  Int_t R4_GetCathodeDetections() {return R4_CathodeDetections;};
+  Int_t R5_GetCathodeDetections() {return R5_CathodeDetections;};
+  Int_t R6_GetCathodeDetections() {return R6_CathodeDetections;};
+  Int_t R7_GetCathodeDetections() {return R7_CathodeDetections;};
+  Int_t R8_GetCathodeDetections() {return R8_CathodeDetections;};
   void SetPMTHitLocation(Int_t id, G4ThreeVector loc, Float_t angle);
   void SetQuartzHitLocation(Int_t id, G4ThreeVector loc);
   Bool_t TrackExists(Int_t ID);

--- a/macros/myRun.mac
+++ b/macros/myRun.mac
@@ -222,13 +222,13 @@
 
 /Det/UpdateGeometry
 
-/Generator/EventHitRegion 1                      #1 = quartz, 2 = lower LG cone, 3 = middle box, 4 = upper LG cone, 5 = 2x2 mm^2 spot on center of quartz, 6 = 2x2 mm^2 on center of lower guide, 7 = 2x2 mm^2 spot on upper guide, 8 = vertically segmented quartz with segment chosen below, 9 = horizontally segmented quartz
+/Generator/EventHitRegion 9                      #1 = quartz, 2 = lower LG cone, 3 = middle box, 4 = upper LG cone, 5 = 2x2 mm^2 spot on center of quartz, 6 = 2x2 mm^2 on center of lower guide, 7 = 2x2 mm^2 spot on upper guide, 8 = vertically segmented quartz with segment chosen below, 9 = horizontally segmented quartz
 /Generator/QuartzHitRegion 0                     #Can be set from 0->9. Selects the cut of the quartz you wish to scan. Value does not matter if EventHitRegion != 7
 /Generator/BeamTheta 0				 #Units of degrees. Not in use
 /Generator/BeamPhi 0				 #Units of degrees. Not in use
 /Generator/BeamSolidAngle 0                       #Units of degrees. Determines angular spread of the beam from the z-axis
 /Generator/BeamEnergy 8000			 #Units of MeV
 
-#/RunAction/SetID 3
-#/random/setSeeds 346082 823457
-#/run/beamOn 1
+/RunAction/SetID 3
+/random/setSeeds 346082 823457
+/run/beamOn 20

--- a/src/MOLLEROptAnalysis.cc
+++ b/src/MOLLEROptAnalysis.cc
@@ -21,8 +21,23 @@ MOLLEROptAnalysis::MOLLEROptAnalysis()
     PMTOptPhotonDistrHist = new TProfile("PMTOptPhotonDistrHist","",800,100,900);
     QuartzOptPhotonDistrHist = new TProfile("QuartzOptPhotonDistrHist","",800,100,900);
     LightGuideOptPhotonDistrHist = new TProfile("LightGuideOptPhotonDistrHist","",800,100,900);
-    PhotoElectronDistrHist = new TH1D("PhotoElectronDistrHist","",100,0,100);
-    CathodeEventsDistrHist = new TH1D("CathodeEventsDistrHist","",100,0,100);
+    R1_PhotoElectronDistrHist = new TH1D("R1_PhotoElectronDistrHist","",100,0,100);
+    R1_CathodeEventsDistrHist = new TH1D("R1_CathodeEventsDistrHist","",100,0,100);
+    R2_PhotoElectronDistrHist = new TH1D("R2_PhotoElectronDistrHist","",100,0,100);
+    R2_CathodeEventsDistrHist = new TH1D("R2_CathodeEventsDistrHist","",100,0,100);
+    R3_PhotoElectronDistrHist = new TH1D("R3_PhotoElectronDistrHist","",100,0,100);
+    R3_CathodeEventsDistrHist = new TH1D("R3_CathodeEventsDistrHist","",100,0,100);
+    R4_PhotoElectronDistrHist = new TH1D("R4_PhotoElectronDistrHist","",100,0,100);
+    R4_CathodeEventsDistrHist = new TH1D("R4_CathodeEventsDistrHist","",100,0,100);
+    R5_PhotoElectronDistrHist = new TH1D("R5_PhotoElectronDistrHist","",100,0,100);
+    R5_CathodeEventsDistrHist = new TH1D("R5_CathodeEventsDistrHist","",100,0,100);
+    R6_PhotoElectronDistrHist = new TH1D("R6_PhotoElectronDistrHist","",100,0,100);
+    R6_CathodeEventsDistrHist = new TH1D("R6_CathodeEventsDistrHist","",100,0,100);
+    R7_PhotoElectronDistrHist = new TH1D("R7_PhotoElectronDistrHist","",100,0,100);
+    R7_CathodeEventsDistrHist = new TH1D("R7_CathodeEventsDistrHist","",100,0,100);
+    R8_PhotoElectronDistrHist = new TH1D("R8_PhotoElectronDistrHist","",100,0,100);
+    R8_CathodeEventsDistrHist = new TH1D("R8_CathodeEventsDistrHist","",100,0,100);
+    
     EventCnt = 0;
 }
 
@@ -64,8 +79,22 @@ void MOLLEROptAnalysis::EndOfRun()
     PMTOptPhotonDistrHist->Write();
     QuartzOptPhotonDistrHist->Write();
     LightGuideOptPhotonDistrHist->Write();
-    PhotoElectronDistrHist->Write();
-    CathodeEventsDistrHist->Write();
+    R1_PhotoElectronDistrHist->Write();
+    R1_CathodeEventsDistrHist->Write();
+    R2_PhotoElectronDistrHist->Write();
+    R2_CathodeEventsDistrHist->Write();
+    R3_PhotoElectronDistrHist->Write();
+    R3_CathodeEventsDistrHist->Write();
+    R4_PhotoElectronDistrHist->Write();
+    R4_CathodeEventsDistrHist->Write();
+    R5_PhotoElectronDistrHist->Write();
+    R5_CathodeEventsDistrHist->Write();
+    R6_PhotoElectronDistrHist->Write();
+    R6_CathodeEventsDistrHist->Write();
+    R7_PhotoElectronDistrHist->Write();
+    R7_CathodeEventsDistrHist->Write();
+    R8_PhotoElectronDistrHist->Write();
+    R8_CathodeEventsDistrHist->Write();
     TrackingReadout->WriteAbsProfiles();
     MOLLEROptFile->Write("",TObject::kOverwrite); // Writing the data to the ROOT file
     

--- a/src/MOLLEROptDetectorEvent.cc
+++ b/src/MOLLEROptDetectorEvent.cc
@@ -79,6 +79,9 @@ void MOLLEROptDetectorEvent::Initialize()
   QuartzHitY.clear();  
   QuartzHitY.resize(0);
 
+  QuartzHitZ.clear();  
+  QuartzHitZ.resize(0);
+
   PMTPhotonEnergy.clear();  
   PMTPhotonEnergy.resize(0);
 

--- a/src/MOLLEROptDetectorEvent.cc
+++ b/src/MOLLEROptDetectorEvent.cc
@@ -112,6 +112,9 @@ void MOLLEROptDetectorEvent::Initialize()
   PMTCathodeHitY.clear();  
   PMTCathodeHitY.resize(0);
 
+  PMTCathodeHitZ.clear();  
+  PMTCathodeHitZ.resize(0);
+
   PMTWindowReflectionAngle.clear();  
   PMTWindowReflectionAngle.resize(0);
 

--- a/src/MOLLEROptEventAction.cc
+++ b/src/MOLLEROptEventAction.cc
@@ -152,6 +152,7 @@ void MOLLEROptEventAction::EndOfEventAction(const G4Event* evt)
 	  PMTSecOptPhotonCnt->Fill(track->InitWavelength,1.0/(bwdt));
 	  analysis->MOLLERMainEvent->MOLLERDetectorEvent.AddPMTHitPositionX((Float_t)track->PMTHitX/cm);
 	  analysis->MOLLERMainEvent->MOLLERDetectorEvent.AddPMTHitPositionY((Float_t)track->PMTHitY/cm);
+    analysis->MOLLERMainEvent->MOLLERDetectorEvent.AddPMTHitPositionZ((Float_t)track->PMTHitZ/cm);
 	  analysis->MOLLERMainEvent->MOLLERDetectorEvent.AddPMTWindowReflectionAngle((Float_t)track->PMTWinRefl);
 	  analysis->MOLLERMainEvent->MOLLERDetectorEvent.AddPMTPhotonEnergy(track->InitKinEnergy/eV);
 	  optPhEng = track->InitKinEnergy/eV;

--- a/src/MOLLEROptEventAction.cc
+++ b/src/MOLLEROptEventAction.cc
@@ -86,7 +86,7 @@ void MOLLEROptEventAction::EndOfEventAction(const G4Event* evt)
 
   G4int hitCnt1, hitCnt2, PMThit, qtrackID, lgtrackID, pmttrackID, ctrackID, LGSteps, QSteps, TSteps, secPhCnt; 
   G4double LGTrackLength, QuartzTrackLength, TotalTrackLength;
-  G4double PMTPe = 0;
+  G4double R1_PMTPe = 0, R2_PMTPe = 0, R3_PMTPe = 0, R4_PMTPe = 0, R5_PMTPe = 0, R6_PMTPe = 0, R7_PMTPe = 0, R8_PMTPe = 0;
   G4int NumSecPhotons = 0;
   G4int hitflag = 0;
  
@@ -160,7 +160,30 @@ void MOLLEROptEventAction::EndOfEventAction(const G4Event* evt)
 	  OptParam* op = TrackingReadout->GetOpticalParameters();
 	  for(int n = 0; n < op->npar-1; n++)
 	    if(optPhEng >= op->EPhoton[n]/eV && optPhEng < op->EPhoton[n+1]/eV){
-	      PMTPe += gRandom->PoissonD(op->QEff[n]);
+	      if((track->PMTHitZ/cm) > 120){
+          R1_PMTPe += gRandom->PoissonD(op->QEff[n]);
+        }
+        if(100 < (track->PMTHitZ/cm) < 120){
+          R2_PMTPe += gRandom->PoissonD(op->QEff[n]);
+        }
+        if(70 < (track->PMTHitZ/cm) < 90){
+          R3_PMTPe += gRandom->PoissonD(op->QEff[n]);
+        }
+        if(50 < (track->PMTHitZ/cm) < 70){
+          R4_PMTPe += gRandom->PoissonD(op->QEff[n]);
+        }
+        if(30 < (track->PMTHitZ/cm) < 50){
+          R5_PMTPe += gRandom->PoissonD(op->QEff[n]);
+        }
+        if(10 < (track->PMTHitZ/cm) < 30 && (track->PMTHitX/cm) < -4){
+          R6_PMTPe += gRandom->PoissonD(op->QEff[n]);
+        }
+        if(10 < (track->PMTHitZ/cm) < 30 && (track->PMTHitX/cm) > 4){
+          R7_PMTPe += gRandom->PoissonD(op->QEff[n]);
+        }
+        if((track->PMTHitZ/cm) < 10){
+          R8_PMTPe += gRandom->PoissonD(op->QEff[n]);
+        }
 	    }
 	  PMThit++;
 	}
@@ -181,9 +204,23 @@ void MOLLEROptEventAction::EndOfEventAction(const G4Event* evt)
     analysis->FillRootNtuple();
   }
   //tempmarker
-  //if()
-  analysis->AddPhotoElectronEvent(PMTPe);
-  analysis->AddCathodeDetectionEvent(TrackingReadout->GetCathodeDetections());
+  analysis->R1_AddPhotoElectronEvent(R1_PMTPe);
+  analysis->R1_AddCathodeDetectionEvent(TrackingReadout->R1_GetCathodeDetections());
+  analysis->R2_AddPhotoElectronEvent(R2_PMTPe);
+  analysis->R2_AddCathodeDetectionEvent(TrackingReadout->R2_GetCathodeDetections());
+  analysis->R3_AddPhotoElectronEvent(R3_PMTPe);
+  analysis->R3_AddCathodeDetectionEvent(TrackingReadout->R3_GetCathodeDetections());
+  analysis->R4_AddPhotoElectronEvent(R4_PMTPe);
+  analysis->R4_AddCathodeDetectionEvent(TrackingReadout->R4_GetCathodeDetections());
+  analysis->R5_AddPhotoElectronEvent(R5_PMTPe);
+  analysis->R5_AddCathodeDetectionEvent(TrackingReadout->R5_GetCathodeDetections());
+  analysis->R6_AddPhotoElectronEvent(R6_PMTPe);
+  analysis->R6_AddCathodeDetectionEvent(TrackingReadout->R6_GetCathodeDetections());
+  analysis->R7_AddPhotoElectronEvent(R7_PMTPe);
+  analysis->R7_AddCathodeDetectionEvent(TrackingReadout->R7_GetCathodeDetections());
+  analysis->R8_AddPhotoElectronEvent(R8_PMTPe);
+  analysis->R8_AddCathodeDetectionEvent(TrackingReadout->R8_GetCathodeDetections());
+  
   
   for(int n = 1; n <= QuartzSecOptPhotonCnt->GetNbinsX(); n++)
     analysis->AddToAverageQuartzOptPhotonDist(QuartzSecOptPhotonCnt->GetBinCenter(n),QuartzSecOptPhotonCnt->GetBinContent(n));

--- a/src/MOLLEROptEventAction.cc
+++ b/src/MOLLEROptEventAction.cc
@@ -123,6 +123,7 @@ void MOLLEROptEventAction::EndOfEventAction(const G4Event* evt)
 	  analysis->MOLLERMainEvent->MOLLERDetectorEvent.AddQuartzTrackHit(1);
 	  analysis->MOLLERMainEvent->MOLLERDetectorEvent.AddQuartzHitPositionX((Float_t)track->QuartzHitX/cm);
 	  analysis->MOLLERMainEvent->MOLLERDetectorEvent.AddQuartzHitPositionY((Float_t)track->QuartzHitY/cm);
+    analysis->MOLLERMainEvent->MOLLERDetectorEvent.AddQuartzHitPositionZ((Float_t)track->QuartzHitZ/cm);
 	}	
 	// for(int p = 0; p < track->SecPhotonAngle.size(); p++){
 	// }
@@ -179,7 +180,8 @@ void MOLLEROptEventAction::EndOfEventAction(const G4Event* evt)
     }
     analysis->FillRootNtuple();
   }
-
+  //tempmarker
+  //if()
   analysis->AddPhotoElectronEvent(PMTPe);
   analysis->AddCathodeDetectionEvent(TrackingReadout->GetCathodeDetections());
   

--- a/src/MOLLEROptPMTSD.cc
+++ b/src/MOLLEROptPMTSD.cc
@@ -93,7 +93,8 @@ G4bool MOLLEROptPMTSD::ProcessHits(G4Step* aStep, G4TouchableHistory* theTouchab
 					aStep->GetTrack()->GetKineticEnergy(),
 					1239.842/(aStep->GetTrack()->GetKineticEnergy()/eV),0);
 	  
-	  TrackingReadout->SetPMTHitLocation(aStep->GetTrack()->GetTrackID(),localpos,incidentAngle);
+	  //TrackingReadout->SetPMTHitLocation(aStep->GetTrack()->GetTrackID(),localpos,incidentAngle);
+	  TrackingReadout->SetPMTHitLocation(aStep->GetTrack()->GetTrackID(),worldpos,incidentAngle);
 	  //HitsCollection->insert(aHit); 
 	// }
       // }

--- a/src/MOLLEROptPrimaryGeneratorAction.cc
+++ b/src/MOLLEROptPrimaryGeneratorAction.cc
@@ -215,7 +215,7 @@ void MOLLEROptPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
   }
   else if(EventRegion == 9){
     //Hits a random location from the top of R6 quartz to the bottom of R1 quartz (may hit empty space on sides of quartz)
-    x = Qlim8[0] + (Qlim8[1]-Qlim8[0])*G4UniformRand();
+    x = Qlim1[0] + (Qlim1[1]-Qlim1[0])*G4UniformRand();
     y = (Qlim1[2] + 1396*TMath::Sin(3*pi/180)) + (Qlim8[3]-Qlim1[2]-1396*TMath::Sin(3*pi/180))*G4UniformRand();
   }
   else{

--- a/src/MOLLEROptTrackingReadout.cc
+++ b/src/MOLLEROptTrackingReadout.cc
@@ -58,13 +58,38 @@ void MOLLEROptTrackingReadout::AddStepNCherenkovs(Int_t id, Int_t nsec)
 
 void MOLLEROptTrackingReadout::IncrementEventCathodeDetection(Int_t id)
 {
-
+  //int ticker = 1;
   for(int n = 0; n < Tracks.size(); n++)
     if(Tracks[n]->ID == id){
       Tracks[n]->Detected = 1;
+      if(Tracks[n]->PMTHitZ/cm > 120 /*&& ticker == 1*/){
+        R1_CathodeDetections++;
+        //ticker++;
+      }
+      if(100 < (Tracks[n]->PMTHitZ/cm) && 120 > (Tracks[n]->PMTHitZ/cm)){
+        R2_CathodeDetections++;
+      }
+      if(70 < (Tracks[n]->PMTHitZ/cm) && 90 > (Tracks[n]->PMTHitZ/cm)){
+        R3_CathodeDetections++;
+      }
+      if(50 < (Tracks[n]->PMTHitZ/cm) && 70 > (Tracks[n]->PMTHitZ/cm)){
+        R4_CathodeDetections++;
+      }
+      if(30 < (Tracks[n]->PMTHitZ/cm) && 50 > (Tracks[n]->PMTHitZ/cm)){
+        R5_CathodeDetections++;
+      }
+      if(10 < (Tracks[n]->PMTHitZ/cm) && 30 > (Tracks[n]->PMTHitZ/cm) && (Tracks[n]->PMTHitX/cm) < -4){
+        R6_CathodeDetections++;
+      }
+      if(10 < (Tracks[n]->PMTHitZ/cm) && 30 > (Tracks[n]->PMTHitZ/cm) && (Tracks[n]->PMTHitX/cm) > 4){
+        R7_CathodeDetections++;
+      }
+      if(Tracks[n]->PMTHitZ/cm < 10){
+        R8_CathodeDetections++;
+      }
     }
   
-  CathodeDetections++;
+  //CathodeDetections++;
 };
 
 
@@ -248,7 +273,15 @@ void MOLLEROptTrackingReadout::Initialize()
   
   ElectronTracks = 0;
   PhotonTracks = 0;
-  CathodeDetections = 0;
+  //CathodeDetections = 0;
+  R1_CathodeDetections = 0;
+  R2_CathodeDetections = 0;
+  R3_CathodeDetections = 0;
+  R4_CathodeDetections = 0;
+  R5_CathodeDetections = 0;
+  R6_CathodeDetections = 0;
+  R7_CathodeDetections = 0;
+  R8_CathodeDetections = 0;
 }
 
  


### PR DESCRIPTION
The PE yield from each detector is now stored in separate histograms.
There is currently an issue where events that lead to 0 PEs in a detector are stored as 0 in the histograms, possibly skewing fits if not handled properly. Will look into fixing this.
There is another issue where the R#_PhotoElectronDistrHist figures show strong PE yields with high statistics when the detector was rarely hit. This plot is not currently being used, but the problem will be looked into as well.